### PR TITLE
add task id description in Viewpending command

### DIFF
--- a/app.py
+++ b/app.py
@@ -244,7 +244,7 @@ def summary():
         taskname = task[4]
         taskdate = task[5]
 
-        pending_tasks += """ SP-{taskid} ({pts} SlackPoints) {taskname} [Deadline: {dt}]./n""".format(
+        pending_tasks += """ Task ID: {taskid} ({pts} SlackPoints) {taskname} [Deadline: {dt}]./n""".format(
             taskid=taskid, pts=points, taskname=taskname, dt=taskdate)
 
     # leaderboard display

--- a/commands/viewpoints.py
+++ b/commands/viewpoints.py
@@ -12,7 +12,7 @@ class ViewPoints:
         "type": "section",
         "text": {
             "type": "mrkdwn",
-            "text": ">SP-{id} ({points} SlackPoints) {description} [Deadline: {deadline}]",
+            "text": ">Task ID: {id} ({points} SlackPoints) {description} [Deadline: {deadline}]",
         },
     }
 

--- a/tests/test_viewcompleted.py
+++ b/tests/test_viewcompleted.py
@@ -43,14 +43,14 @@ def test_view_completed_2tasks(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": ">SP-3 (5 SlackPoints) This is Task 3 [Deadline: 2022-08-24]",
+                    "text": ">Task ID: 3 (5 SlackPoints) This is Task 3 [Deadline: 2022-08-24]",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": ">SP-4 (5 SlackPoints) This is Task 4 [Deadline: 2022-08-26]",
+                    "text": ">Task ID: 4 (5 SlackPoints) This is Task 4 [Deadline: 2022-08-26]",
                 },
             },
         ],

--- a/tests/test_viewpending.py
+++ b/tests/test_viewpending.py
@@ -44,14 +44,14 @@ def test_view_pending_2tasks(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": ">SP-1 (10 SlackPoints) This is Task 1 [Deadline: 2022-10-24]",
+                    "text": ">Task ID: 1 (10 SlackPoints) This is Task 1 [Deadline: 2022-10-24]",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": ">SP-2 (2 SlackPoints) This is Task 2 [Deadline: 2022-10-26]",
+                    "text": ">Task ID: 2 (2 SlackPoints) This is Task 2 [Deadline: 2022-10-26]",
                 },
             },
         ],


### PR DESCRIPTION
The bot was not showing task ids in /viewpending clearly. It was prefixed with 'SP-' which confused the user which was the real task id